### PR TITLE
CNN API

### DIFF
--- a/server/controller/news_controller.js
+++ b/server/controller/news_controller.js
@@ -14,7 +14,6 @@ class News {
                 next(err);
             })
     }
-
     static getCovidNews(req, res, next) {
         axios.get('https://newsapi.org/v2/everything?' +
             'qInTitle=covid+Indonesia&' +
@@ -27,17 +26,100 @@ class News {
                 next(err);
             })
     }
-
-    static getCovidHeadlines(req, res, next) {
-        axios.get('https://dekontaminasi.com/api/id/covid19/hospitals')
-            .then(data => {
-                console.log(data)
-                res.status(200).json(data.data);
-            })
-            .catch(err => {
-                next(err);
-            })
+    static allNews(req, res, next){
+        axios.get('https://www.news.developeridn.com/')
+        .then(data => {
+            // console.log(data);
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
     }
+    static nationalNews(req,res,next){
+        axios.get('https://www.news.developeridn.com/nasional')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static internationalNews(req,res,next){
+        axios.get('https://www.news.developeridn.com/internasional')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static economicNews(req,res,next){
+        axios.get('https://www.news.developeridn.com/ekonomi')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static sportNews(req,res,next){
+        axios.get('https://www.news.developeridn.com/olahraga')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static techNews(req,res,next){
+        axios.get('https://www.news.developeridn.com/teknologi')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static entertainment(req,res,next){
+        axios.get('https://www.news.developeridn.com/hiburan')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static lifetyle(req,res,next){
+        axios.get(' 	https://www.news.developeridn.com/gaya-hidupp')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static detailNews(req,res,next){ 
+        const url = req.body.url
+        axios.get(`https://www.news.developeridn.com/detail/?url=${url}`)
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+    static findNews(req,res,next){
+        axios.get('https://www.news.developeridn.com/search/?q=covid')
+        .then(data=>{
+            res.status(200).json(data.data.data)
+        })
+        .catch(err =>{
+            next(err)
+        })
+    }
+
+    
 }
 
 module.exports = News

--- a/server/routers/news.js
+++ b/server/routers/news.js
@@ -3,6 +3,15 @@ const news_controller = require('../controller/news_controller')
 
 routers.get('/', news_controller.getHeadline)
 routers.get('/covid', news_controller.getCovidNews)
-routers.get('/covid-headlines', news_controller.getCovidHeadlines)
+routers.get('/allnews', news_controller.allNews)
+routers.get('/nationalnews', news_controller.nationalNews)
+routers.get('/internationalnews', news_controller.internationalNews)
+routers.get('/economicnews', news_controller.economicNews)
+routers.get('/sportnews', news_controller.sportNews)
+routers.get('/technews', news_controller.techNews)
+routers.get('/entertainment', news_controller.entertainment)
+routers.get('/lifestyle', news_controller.lifetyle)// server error
+routers.get('/detailnews', news_controller.detailNews)
+routers.get('/findnews', news_controller.findNews)
 
 module.exports = routers


### PR DESCRIPTION
1. Menambahkan fitur mencari semua jenis news dari CNN serta membuat routing /news/allnews
2. Menambahkan fitur mencari semua jenis news dari CNN Nasional serta membuat routing /news/nationalnews
3. Menambahkan fitur mencari semua jenis news dari CNN International serta membuat routing /news/internationalnews
4. Menambahkan fitur mencari news economic dari CNN Indonesia serta membuat routing /news/economicnews
5. Menambahkan fitur mencari news sport dari CNN Indonesia serta membuat routing /news/sportnews
6. Menambahkan fitur mencari news Tech dari CNNIndonesia serta membuat routing /news/technews
7. Menambahkan fitur mencari news entertainment dari CNN Indonesia serta membuat routing /news/entertainment
8. Menambahkan fiitur mencari news lifestyle dari CNN Indonesia serta membuat routing /news/lifestyle
9.Menambahkan fitur mencari news detail news dengan parameter yang bisa di input dengan req,body dari Indonesia serta membuat routing /news/detailnews
10. Menambahkan fitur mencari news dengan spesifikasi kategori covid dari CNN Indonesia serta membuat routing /news/findnews